### PR TITLE
CFG-64 add map float values

### DIFF
--- a/fixtures/semantic_api.json
+++ b/fixtures/semantic_api.json
@@ -531,9 +531,32 @@
                   "type": "boolean"
               },
               "x-proto-tag": 13
-          }
-        }
-    }
+            },
+            "test_map_scalar_float": {
+              "type": "object",
+              "additionalProperties": {
+                  "type": "number",
+                  "format": "float"
+              },
+              "x-proto-tag": 14
+            },
+            "test_map_scalar_double": {
+              "type": "object",
+              "additionalProperties": {
+                  "type": "number",
+                  "format": "double"
+              },
+              "x-proto-tag": 15
+            },
+            "test_map_scalar_double_none": {
+              "type": "object",
+              "additionalProperties": {
+                  "type": "number"
+              },
+              "x-proto-tag": 16
+            }
+         }
+      }
   },
   "securityDefinitions": {
       "apikey": {

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -209,6 +209,9 @@ message TestModel {
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     map<string, bool> test_map_scalar_bool = 13;
+    map<string, float> test_map_scalar_float = 14;
+    map<string, double> test_map_scalar_double = 15;
+    map<string, double> test_map_scalar_double_none = 16;
     google.protobuf.DoubleValue test_num_value = 5;
     google.protobuf.DoubleValue test_numer_value = 6;
     google.protobuf.StringValue test_string_value = 8;

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -209,9 +209,9 @@ message TestModel {
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     map<string, bool> test_map_scalar_bool = 13;
-    map<string, float> test_map_scalar_float = 14;
-    map<string, double> test_map_scalar_double = 15;
-    map<string, double> test_map_scalar_double_none = 16;
+    map<string, float32> test_map_scalar_float = 14;
+    map<string, float64> test_map_scalar_double = 15;
+    map<string, float64> test_map_scalar_double_none = 16;
     google.protobuf.DoubleValue test_num_value = 5;
     google.protobuf.DoubleValue test_numer_value = 6;
     google.protobuf.StringValue test_string_value = 8;

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -209,9 +209,9 @@ message TestModel {
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     map<string, bool> test_map_scalar_bool = 13;
-    map<string, float32> test_map_scalar_float = 14;
-    map<string, float64> test_map_scalar_double = 15;
-    map<string, float64> test_map_scalar_double_none = 16;
+    map<string, float> test_map_scalar_float = 14;
+    map<string, double> test_map_scalar_double = 15;
+    map<string, double> test_map_scalar_double_none = 16;
     google.protobuf.DoubleValue test_num_value = 5;
     google.protobuf.DoubleValue test_numer_value = 6;
     google.protobuf.StringValue test_string_value = 8;

--- a/openapi.go
+++ b/openapi.go
@@ -346,13 +346,13 @@ func protoComplex(i *Items, typ, msgName, name string, defs map[string]*Items, i
 					if i.AdditionalProperties.Format != nil {
 						itemFormat := i.AdditionalProperties.Format.(string)
 						if itemFormat == "float" {
-							itemType = "float"
+							itemType = "float32"
 						}
 						if itemFormat == "double" {
-							itemType = "double"
+							itemType = "float64"
 						}
 					} else {
-						itemType = "double"
+						itemType = "float64"
 					}
 				}
 			}

--- a/openapi.go
+++ b/openapi.go
@@ -346,13 +346,13 @@ func protoComplex(i *Items, typ, msgName, name string, defs map[string]*Items, i
 					if i.AdditionalProperties.Format != nil {
 						itemFormat := i.AdditionalProperties.Format.(string)
 						if itemFormat == "float" {
-							itemType = "float32"
+							itemType = "float"
 						}
 						if itemFormat == "double" {
-							itemType = "float64"
+							itemType = "double"
 						}
 					} else {
-						itemType = "float64"
+						itemType = "double"
 					}
 				}
 			}

--- a/openapi.go
+++ b/openapi.go
@@ -342,6 +342,19 @@ func protoComplex(i *Items, typ, msgName, name string, defs map[string]*Items, i
 				if itemType == "boolean" {
 					itemType = "bool"
 				}
+				if itemType == "number" {
+					if i.AdditionalProperties.Format != nil {
+						itemFormat := i.AdditionalProperties.Format.(string)
+						if itemFormat == "float" {
+							itemType = "float"
+						}
+						if itemFormat == "double" {
+							itemType = "double"
+						}
+					} else {
+						itemType = "double"
+					}
+				}
 			}
 			return fmt.Sprintf("map<string, %s> %s = %d", itemType, name, *index)
 		}


### PR DESCRIPTION
Second PR for the same thing. The first one was created by mistake from the master branch. However `go -get` fetches the karhoo branch, so a new PR to add generation of maps with float values.

The tests show a red herring failure due to existence of invisible characters:

>                 [32mmap<string, float64> test_map_scalar_double = 15;
>                 map<string, float64> test_map_scalar_double_none = 16;
>                 map<string, float32> test_map_scalar_float = 14;
>                 [0mgoogle.protobuf.DoubleValue test_num_value = 5;

Tried to get rid of them with little success. The implementation works as shown by running:

               _go run cmd/openapi2proto/main.go -spec fixtures/semantic_api.json_